### PR TITLE
make pipewire controllable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(QT_MIN_VERSION "5.10.0")
 include(LiriSetup)
 
 ## Features:
+option(LIRI_ENABLE_PIPEWIRE "Enable pipewire support" OFF)
 option(LIRI_ENABLE_SYSTEMD "Enable systemd support" ON)
 add_feature_info("Liri::Systemd" LIRI_ENABLE_SYSTEMD "Enable systemd support")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,9 +18,8 @@ if(NOT TARGET Liri::Xdg)
     find_package(Liri1Xdg REQUIRED)
 endif()
 
-find_package(PipeWire)
-
-if(TARGET PkgConfig::PipeWire)
+if(LIRI_ENABLE_PIPEWIRE)
+    find_package(PipeWire REQUIRED)
     find_package(Libdrm REQUIRED)
 endif()
 
@@ -104,9 +103,11 @@ liri_add_executable(XdgDesktopPortalLiri
         Liri::Xdg
 )
 
-if(TARGET PkgConfig::PipeWire)
-    liri_extend_target("XdgDesktopPortalLiri"
-        DEFINES SCREENCAST_ENABLED
-        SOURCES "${screencast_SOURCES}"
-        LIBRARIES "PkgConfig::PipeWire;PkgConfig::Libdrm")
+if(LIRI_ENABLE_PIPEWIRE)
+    if(TARGET PkgConfig::PipeWire)
+        liri_extend_target("XdgDesktopPortalLiri"
+            DEFINES SCREENCAST_ENABLED
+            SOURCES "${screencast_SOURCES}"
+            LIBRARIES "PkgConfig::PipeWire;PkgConfig::Libdrm")
+    endif()
 endif()


### PR DESCRIPTION
Signed-off-by: Aisha Tammy <floss@bsd.ac>

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does the code keep building with this change?
- [x] Do the unit tests pass with this change?
- [x] Is the commit message formatted according to CONTRIBUTING.MD?
- [ ] If this change fixes a bug (or a performance problem), is a regression
  test (or a benchmark) included?
- [ ] Is a documentation update included (if this change modifies
  existing APIs, or introduces new ones)

_NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open._

### Affected core subsystem(s)

Please provide affected core subsystem(s).

### Description of change

Makes pipewire usage be controlled with cmake option. Helps in creating portage builds.
